### PR TITLE
Update create-ykdl-unix.sh

### DIFF
--- a/create-ykdl/create-ykdl-unix.sh
+++ b/create-ykdl/create-ykdl-unix.sh
@@ -6,7 +6,7 @@ HERE="$(dirname "$(readlink -f "${0}")")"
 if [ -d ykdl ]; then
     rm -rf ykdl
 fi
-git clone 'https://github.com/zhangn1985/ykdl.git'
+git clone 'https://github.com/SeaHOH/ykdl.git'
 
 # Copy patched file
 cp "${HERE}/ykdl_main.py" ykdl/__main__.py


### PR DESCRIPTION
ykdl的最新插件维护已经转移到新的地址，对更新插件地址进行了更新。
A video downloader focus on China mainland video sites.

Origin website: https://github.com/zhangn1985/ykdl

Now, it has migrated to the new website: https://github.com/SeaHOH/ykdl